### PR TITLE
supported string data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Take a nested Map and flatten it with delimited keys. Entirely based on node.js 
 ```dart
 import 'package:flat/flat.dart';
 
-flatten({
+flatten(target:{
   'key1': {'keyA': 'valueI'},
   'key2': {'keyB': 'valueII'},
   'key3': {
@@ -41,7 +41,7 @@ When enabled, flat will preserve arrays and their contents. This is disabled by 
 ```dart
 import 'package:flat/flat.dart';
 
-flatten({
+flatten(target:{
   'this': [
     {'contains': 'arrays'},
     {
@@ -67,7 +67,7 @@ Maximum number of nested objects to flatten.
 ```dart
 import 'package:flat/flat.dart';
 
-flatten({
+flatten(target:{
   'key1': {'keyA': 'valueI'},
   'key2': {'keyB': 'valueII'},
   'key3': {

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,7 +1,7 @@
 import 'package:flat/flat.dart';
 
 void main() {
-  final flat = flatten({
+  final flat = flatten(target: {
     "a": 1,
     "b": {"c": 2}
   });

--- a/lib/flat.dart
+++ b/lib/flat.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// Flatten a nested Map into a single level map
 ///
 /// If no [delimiter] is specified, will separate depth levels by `.`.
@@ -7,8 +9,11 @@
 ///
 /// To avoid circular reference issues or huge calculations,
 /// you can specify the [maxDepth] the function will traverse.
-Map<String, Object> flatten(
-  Map<String, Object> target, {
+/// [target]
+
+Map<String, Object> flatten({
+  Map<String, Object> target, 
+  String data,
   String delimiter = ".",
   bool safe = false,
   int maxDepth,
@@ -36,8 +41,9 @@ Map<String, Object> flatten(
       result[newKey] = value;
     });
   }
-
-  step(target);
+  
+  step(target == null ? jsonDecode(data) : target) ;
+  
 
   return result;
 }


### PR DESCRIPTION
get the target from `Sting` data 
example :
``` dart
var str = '''{
    "a": 1,
    "b": {"c": 2}
  }''';
final flat = flatten(data: str);
  print(flat);
```

