### PR TITLE
Remove unnecessary cast (causing library to throw when processing List) 

### DIFF
--- a/lib/flat.dart
+++ b/lib/flat.dart
@@ -32,7 +32,7 @@ Map<String, dynamic> flatten(
       }
       if (value is List && !safe) {
         return step(
-          _listToMap(value as List<Object>),
+          _listToMap(value),
           newKey,
           currentDepth + 1,
         );


### PR DESCRIPTION
Error flattening following valid json containing a List of Map
{ "mediaData": { "resources": [ { "uri": "spotify://", "mimeType": "audio/unknown" } ] } }

Error reported : Expected a value of type 'List<Object>', but got one of type 'List<dynamic>'

As stated in the previous PR, the casting is no longer required